### PR TITLE
config: notify the service on config files changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+### 2024-01-09 1.2.0
+* Explicitly notify the service

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,14 +2,14 @@
 class grafana::config {
   assert_private()
 
-  $directory = $::grafana::config_dir
+  $directory = $grafana::config_dir
 
-  if $::grafana::config_file {
+  if $grafana::config_file {
     deprecation(
       'grafana::config_file',
       'This setting is deprecated and will be removed in future release.'
     )
-    $file = $::grafana::config_file
+    $file = $grafana::config_file
   } else {
     $file = "${directory}/grafana.ini"
   }
@@ -19,21 +19,22 @@ class grafana::config {
     purge   => true,
     recurse => true,
     force   => true,
-    owner   => $::grafana::user,
-    group   => $::grafana::group,
+    owner   => $grafana::user,
+    group   => $grafana::group,
     mode    => '0750',
   }
 
   file { $file:
     ensure => file,
-    owner  => $::grafana::user,
-    group  => $::grafana::group,
+    owner  => $grafana::user,
+    group  => $grafana::group,
     mode   => '0640',
+    notify => $grafana::service_name,
   }
 
-  $::grafana::settings.each |$section, $params| {
+  $grafana::settings.each |$section, $params| {
     $_section = regsubst($section, '\.', '_', 'G')
 
-    create_resources('class', {"::grafana::settings::${_section}" => $params})
+    create_resources('class', { "grafana::settings::${_section}" => $params })
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "arcaik-grafana",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "author": "Johan Fleury (Arcaik)",
   "summary": "Configuration and management of Grafana",
   "license": "GPL-3.0",


### PR DESCRIPTION


  Currently config changes require a manual restart.  This change adds an
  explicit notify to the grafana service.

  It seems from the the following in the init file that this was the
  intention however it is no working

   Class['::grafana::install']
    -> Class['::grafana::config']
    ~> Class['::grafana::service']